### PR TITLE
Fixed typo in Cron.php

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -12,7 +12,7 @@
 
 namespace Ebizmarts\AbandonedCart\Model;
 
-class cron
+class Cron
 {
     protected $days;
     protected $maxtimes;


### PR DESCRIPTION
Fixed a typo error that breaks `setup:di:compile` : 

`Class \\Ebizmarts\\AbandonedCart\\Model\\cron does not exist`
