### PR TITLE
Fix some issues with email templates

### DIFF
--- a/Model/Cron.php
+++ b/Model/Cron.php
@@ -254,7 +254,7 @@ class Cron
                             $vars = array('quote' => $quote, 'url' => $url, 'couponcode' => $couponcode, 'name' => $name, 'tags' => array($this->mandrillTag), 'unsubscribeurl' => $unsubscribeUrl);
                         }
                     } else {
-                        $vars = array('quote' => $quote, 'url' => $url, 'unsubscribeurl' => $unsubscribeUrl, 'tags' => array($this->mandrillTag),'subject'=>$mailSubject);
+                        $vars = array('quote' => $quote, 'url' => $url, 'unsubscribeurl' => $unsubscribeUrl, 'name' => $name, 'tags' => array($this->mandrillTag),'subject'=>$mailSubject);
                     }
                     $transport = $this->_transportBuilder->setTemplateIdentifier($templateId)
                         ->setTemplateOptions(['area' => \Magento\Backend\App\Area\FrontNameResolver::AREA_CODE, 'store' => $storeId])

--- a/view/adminhtml/email/abandoned_cart_mail_1.html
+++ b/view/adminhtml/email/abandoned_cart_mail_1.html
@@ -16,7 +16,7 @@
                     <tr>
                         <td valign="top">
                             <h1 style="font-size:22px; font-weight:normal; line-height:22px; margin:0 0 11px 0;">Hello,
-                                {{var $name}}</h1>
+                                {{var name}}</h1>
 
                             <p style="font-size:12px; line-height:16px; margin:0;">
                                 You have an abandoned cart at {{var store.getFrontendName()}}.

--- a/view/adminhtml/email/abandoned_cart_mail_2.html
+++ b/view/adminhtml/email/abandoned_cart_mail_2.html
@@ -16,7 +16,7 @@
                     <tr>
                         <td valign="top">
                             <h1 style="font-size:22px; font-weight:normal; line-height:22px; margin:0 0 11px 0;">Hello,
-                                {{htmlescape var=$name}}</h1>
+                                {{var name}}</h1>
 
                             <p style="font-size:12px; line-height:16px; margin:0;">
                                 You have an abandoned cart at {{var store.getFrontendName()}}.


### PR DESCRIPTION
This PR fixes some issues with base email templates of the module. 
1. Removes obsolete htmlescape directive from view/adminhtml/email/abandoned_cart_mail_2.html
2. Customer name was not passed to email vars if coupon code is not sent.